### PR TITLE
server.js の middleware 内の冗長なコードを修正

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,10 +36,7 @@ server.use((req, res, next) => {
   }
 
   try {
-    const decode = jwt.verify(
-      req.headers.authorization.split(" ")[1],
-      SECRET_KEY
-    );
+    jwt.verify(req.headers.authorization.split(" ")[1], SECRET_KEY);
     next();
   } catch (e) {
     res.status(401).json("Unauthorized");

--- a/server.js
+++ b/server.js
@@ -31,8 +31,7 @@ server.use((req, res, next) => {
     req.headers.authorization === undefined ||
     req.headers.authorization.split(" ")[0] !== "Bearer"
   ) {
-    res.status(401).json("Unauthorized");
-    return;
+    return res.status(401).json("Unauthorized");
   }
 
   try {

--- a/server.js
+++ b/server.js
@@ -27,15 +27,14 @@ server.post("/auth/signin", (req, res) => {
 });
 
 server.use((req, res, next) => {
-  if (
-    req.headers.authorization === undefined ||
-    req.headers.authorization.split(" ")[0] !== "Bearer"
-  ) {
+  const auth = req.headers.authorization?.split(" ");
+
+  if (auth?.[0] !== "Bearer") {
     return res.status(401).json("Unauthorized");
   }
 
   try {
-    jwt.verify(req.headers.authorization.split(" ")[1], SECRET_KEY);
+    jwt.verify(auth[1] ?? "", SECRET_KEY);
     next();
   } catch (e) {
     res.status(401).json("Unauthorized");


### PR DESCRIPTION
1. 不要な変数定義を削除 
   - 676b8ee
2. res.status(401).json("Unauthorized") を直接リターンするように変更
   - dd32afc
3. req.headers.authorization.split(" ") を auth 変数に保存し、変更箇所での調整
   - 375f385