### PR TITLE
fix: server.js の post 内のデータベース検索結果を変数に保存し、 jwt.sign の引数を変更

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,11 @@ server.post("/auth/signin", (req, res) => {
     return res.status(401).json("Unauthorized");
   }
 
-  const token = jwt.sign({ email, password }, SECRET_KEY, OPTION);
+  const token = jwt.sign(
+    { id: user.id, email: user.email },
+    SECRET_KEY,
+    OPTION
+  );
   res.status(200).json({ token });
 });
 

--- a/server.js
+++ b/server.js
@@ -12,16 +12,18 @@ server.use(middlewares);
 server.use(jsonServer.bodyParser);
 
 server.post("/auth/signin", (req, res) => {
-  const { email, id } = req.body;
+  const { email, password } = req.body;
   const OPTION = {
     expiresIn: "30m",
   };
 
-  if (!db.users.some((user) => user.email === email && user.id === id)) {
+  if (
+    !db.users.some((user) => user.email === email && user.password === password)
+  ) {
     return res.status(401).json("Unauthorized");
   }
 
-  const token = jwt.sign({ email, id }, SECRET_KEY, OPTION);
+  const token = jwt.sign({ email, password }, SECRET_KEY, OPTION);
   res.status(200).json({ token });
 });
 

--- a/server.js
+++ b/server.js
@@ -16,10 +16,11 @@ server.post("/auth/signin", (req, res) => {
   const OPTION = {
     expiresIn: "30m",
   };
+  const user = db.users.find(
+    (user) => user.email === email && user.password === password
+  );
 
-  if (
-    !db.users.some((user) => user.email === email && user.password === password)
-  ) {
+  if (!user) {
     return res.status(401).json("Unauthorized");
   }
 


### PR DESCRIPTION
## 変更内容
- `/auth/signin` の API を email、password の形に変更
1. `req.body` から受け取る変数を `id` から `password` へ変更、またデータベース検索条件も変更、`jwt.sign` の第１引数の変更はミスですが、**3.** で変更が予定されるため、問題ないです
2. データベース検索結果を `user` 変数に保存し、変更箇所の調整
3. `jwt.sign` の第１引数を `req` から受け取った値でなく、**2.** で保存した `user` での値へ変更

## 確認方法
1. `node server.js` で APIサーバーを起動
2. 以下の curl で token が返る　
```sh
curl -X POST -H "Content-Type: application/json" -d '{"email":"admin","password":"admin"}' http://localhost:5000/auth/signin
```
3. https://jwt.io/ の Encoded に取得した token を入力すると Decoded の PAYLOAD に id と email が入っている