### PR TITLE
有効なトークンの有無によってのアクセス先の変更

### DIFF
--- a/src/components/ProvideAuth.js
+++ b/src/components/ProvideAuth.js
@@ -1,5 +1,7 @@
 import { useState, useContext, createContext } from "react";
+import jwt from "jsonwebtoken";
 
+const SECRET_KEY = "abcdefg";
 const authContext = createContext();
 const { Provider } = authContext;
 
@@ -8,7 +10,14 @@ export const useAuth = () => {
 };
 
 function useProvideAuth() {
-  const [isSignIn, setIsSignIn] = useState(false);
+  try {
+    jwt.verify(localStorage.getItem("token") ?? "", SECRET_KEY);
+  } catch (e) {
+    localStorage.clear();
+  }
+
+  const token = localStorage.getItem("token");
+  const [isSignIn, setIsSignIn] = useState(token ? true : false);
 
   const UseProvideAuth = {
     isSignIn,


### PR DESCRIPTION
## 追加内容
1. アプリアクセスに有効なトークン（期限が切れてない）を所持している場合、`Todo`へリダイレクトし、持っていない場合、`Signin`へリダイレクトするように変更

## 確認方法
`server.js`の`/auth/signin`内の`expiresIn`オプションを短く設定し、アプリアクセス後にすぐのリロードと時間経過後にリロードしてみる

