### PR TITLE
サインアウト機能の追加 #28

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,15 +5,10 @@ import { useAuth } from "./ProvideAuth";
 const Header = ({ title }) => {
   const { signOut } = useAuth();
 
-  const onClick = () => {
-    localStorage.clear();
-    signOut();
-  };
-
   return (
     <header>
       <h1>{title}</h1>
-      <Button color={"darkblue"} text={"Sign Out"} onClick={onClick} />
+      <Button color={"darkblue"} text={"Sign Out"} onClick={signOut} />
     </header>
   );
 };

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,9 +1,19 @@
 import PropTypes from "prop-types";
+import Button from "./Button";
+import { useAuth } from "./ProvideAuth";
 
 const Header = ({ title }) => {
+  const { signOut } = useAuth();
+
+  const onClick = () => {
+    localStorage.clear();
+    signOut();
+  };
+
   return (
     <header>
       <h1>{title}</h1>
+      <Button color={"darkblue"} text={"Sign Out"} onClick={onClick} />
     </header>
   );
 };

--- a/src/components/ProvideAuth.js
+++ b/src/components/ProvideAuth.js
@@ -26,6 +26,7 @@ function useProvideAuth() {
     },
     signOut() {
       setIsSignIn(false);
+      localStorage.clear();
     },
   };
 


### PR DESCRIPTION
## 追加内容　21//07/14 更新
1. `Header.js`内の`onClick`関数を削除し`onClick`ハンドラに`signOut`を渡すように変更
2. `ProvideAuth`内の`signOut`関数に`localStorage.clear()`を追加

## 追加内容
1. `localStorage`をクリアして、サインアウトする機能を追加しました
