### PR TITLE
パスワードを変更する機能の追加

### DIFF
--- a/server.js
+++ b/server.js
@@ -66,7 +66,7 @@ server.use((req, res, next) => {
   }
 
   try {
-    jwt.verify(auth[1] ?? "", SECRET_KEY);
+    req.payload = jwt.verify(auth[1] ?? "", SECRET_KEY);
     next();
   } catch (e) {
     res.status(401).json("Unauthorized");

--- a/server.js
+++ b/server.js
@@ -74,18 +74,23 @@ server.use((req, res, next) => {
 });
 
 server.put("/users/password", (req, res) => {
-  const { id, currentPassword, newPassword } = req.body;
+  const { payload, currentPassword, newPassword } = req.body;
 
   const user = db
     .get("users")
     .value()
-    .find((user) => user.id === id && user.password === currentPassword);
+    .find(
+      (user) => user.id === payload.id && user.password === currentPassword
+    );
 
   if (!user) {
     return res.status(400).json("Wrong Current Password");
   }
 
-  db.get("users").find({ id: id }).assign({ password: newPassword }).write();
+  db.get("users")
+    .find({ id: payload.id })
+    .assign({ password: newPassword })
+    .write();
   res.status(200).json("Password Changed");
 });
 

--- a/server.js
+++ b/server.js
@@ -59,12 +59,12 @@ server.post("/auth/signin", (req, res) => {
 });
 
 server.put("/change/password", (req, res) => {
-  const { id, crntPassword, newPassword } = req.body;
+  const { id, currentPassword, newPassword } = req.body;
 
   const user = db
     .get("users")
     .value()
-    .find((user) => user.id === id && user.password === crntPassword);
+    .find((user) => user.id === id && user.password === currentPassword);
 
   if (!user) {
     return res.status(400).json("Wrong Current Password");

--- a/server.js
+++ b/server.js
@@ -58,6 +58,22 @@ server.post("/auth/signin", (req, res) => {
   res.status(200).json({ token });
 });
 
+server.put("/change/password", (req, res) => {
+  const { id, crntPassword, newPassword } = req.body;
+
+  const user = db
+    .get("users")
+    .value()
+    .find((user) => user.id === id && user.password === crntPassword);
+
+  if (!user) {
+    return res.status(400).json("Wrong Current Password");
+  }
+
+  db.get("users").find({ id: id }).assign({ password: newPassword }).write();
+  res.status(200).json("Password Changed");
+});
+
 server.use((req, res, next) => {
   const auth = req.headers.authorization?.split(" ");
 

--- a/server.js
+++ b/server.js
@@ -58,33 +58,6 @@ server.post("/auth/signin", (req, res) => {
   res.status(200).json({ token });
 });
 
-server.put("/users/password", (req, res) => {
-  const { id, currentPassword, newPassword } = req.body;
-  const auth = req.headers.authorization?.split(" ");
-
-  if (auth?.[0] !== "Bearer") {
-    return res.status(401).json("Unauthorized");
-  }
-
-  try {
-    jwt.verify(auth[1] ?? "", SECRET_KEY);
-  } catch (e) {
-    return res.status(401).json("Unauthorized");
-  }
-
-  const user = db
-    .get("users")
-    .value()
-    .find((user) => user.id === id && user.password === currentPassword);
-
-  if (!user) {
-    return res.status(400).json("Wrong Current Password");
-  }
-
-  db.get("users").find({ id: id }).assign({ password: newPassword }).write();
-  res.status(200).json("Password Changed");
-});
-
 server.use((req, res, next) => {
   const auth = req.headers.authorization?.split(" ");
 
@@ -98,6 +71,22 @@ server.use((req, res, next) => {
   } catch (e) {
     res.status(401).json("Unauthorized");
   }
+});
+
+server.put("/users/password", (req, res) => {
+  const { id, currentPassword, newPassword } = req.body;
+
+  const user = db
+    .get("users")
+    .value()
+    .find((user) => user.id === id && user.password === currentPassword);
+
+  if (!user) {
+    return res.status(400).json("Wrong Current Password");
+  }
+
+  db.get("users").find({ id: id }).assign({ password: newPassword }).write();
+  res.status(200).json("Password Changed");
 });
 
 server.use(router);

--- a/server.js
+++ b/server.js
@@ -75,6 +75,16 @@ server.use((req, res, next) => {
 
 server.put("/users/password", (req, res) => {
   const { payload, currentPassword, newPassword } = req.body;
+  const auth = req.headers.authorization?.split(" ");
+
+  try {
+    const decoded = jwt.verify(auth[1] ?? "", SECRET_KEY);
+    if (payload.id !== decoded.id || payload.email !== decoded.email) {
+      return res.status(400).json("Not match token and payload");
+    }
+  } catch (e) {
+    return res.status(401).json("Unauthorized");
+  }
 
   const user = db
     .get("users")

--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@ server.post("/auth/signin", (req, res) => {
   res.status(200).json({ token });
 });
 
-server.put("/change/password", (req, res) => {
+server.put("/users/password", (req, res) => {
   const { id, currentPassword, newPassword } = req.body;
 
   const user = db

--- a/server.js
+++ b/server.js
@@ -60,6 +60,17 @@ server.post("/auth/signin", (req, res) => {
 
 server.put("/users/password", (req, res) => {
   const { id, currentPassword, newPassword } = req.body;
+  const auth = req.headers.authorization?.split(" ");
+
+  if (auth?.[0] !== "Bearer") {
+    return res.status(401).json("Unauthorized");
+  }
+
+  try {
+    jwt.verify(auth[1] ?? "", SECRET_KEY);
+  } catch (e) {
+    return res.status(401).json("Unauthorized");
+  }
 
   const user = db
     .get("users")

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ const App = () => {
       <PrivateRoute exact path="/todos" component={TodoApp} />
       <UnAuthRoute exact path="/signin" component={SignIn} />
       <UnAuthRoute exact path="/signup" component={SignUp} />
-      <ChangePassword exact path="/change/password" />
+      <PrivateRoute exact path="/change/password" component={ChangePassword} />
       <Redirect to="/todos" />
     </Switch>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import SignIn from "./components/SignIn";
 import SignUp from "./components/SignUp";
 import { PrivateRoute } from "./components/PrivateRoute";
 import { UnAuthRoute } from "./components/UnAuthRoute";
+import ChangePassword from "./components/ChangePassword";
 
 const App = () => {
   return (
@@ -13,6 +14,7 @@ const App = () => {
       <PrivateRoute exact path="/todos" component={TodoApp} />
       <UnAuthRoute exact path="/signin" component={SignIn} />
       <UnAuthRoute exact path="/signup" component={SignUp} />
+      <ChangePassword exact path="/change/password" />
       <Redirect to="/todos" />
     </Switch>
   );

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -26,7 +26,7 @@ const ChangePassword = () => {
 
     try {
       axios.put("http://localhost:5000/users/password", {
-        id: decoded.id,
+        payload: decoded,
         currentPassword,
         newPassword,
       });

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -20,7 +20,7 @@ const ChangePassword = () => {
     }
 
     try {
-      axios.put("http://localhost:5000/change/password", {
+      axios.put("http://localhost:5000/users/password", {
         id: decoded.id,
         currentPassword,
         newPassword,

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -1,8 +1,5 @@
 import { useState } from "react";
 import axios from "axios";
-import jwt from "jsonwebtoken";
-
-const SECRET_KEY = "abcdefg";
 
 const ChangePassword = () => {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -24,7 +21,7 @@ const ChangePassword = () => {
 
     try {
       await axios.put("http://localhost:5000/users/password", {
-        payload: jwt.verify(token, SECRET_KEY),
+        payload: JSON.parse(localStorage.getItem("payload")),
         currentPassword,
         newPassword,
       });

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import axios from "axios";
 import jwt from "jsonwebtoken";
+import { useAuth } from "./ProvideAuth";
+import { Redirect } from "react-router-dom";
 
 const SECRET_KEY = "abcdefg";
 
@@ -8,6 +10,7 @@ const ChangePassword = () => {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const token = localStorage.getItem("token");
+  const { isSignIn } = useAuth();
 
   if (token) {
     axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
@@ -39,7 +42,7 @@ const ChangePassword = () => {
     }
   };
 
-  return (
+  return isSignIn ? (
     <form onSubmit={changePassword}>
       <div>
         <p>Current Password</p>
@@ -59,6 +62,8 @@ const ChangePassword = () => {
         <input className="btn" type="submit" value="Enter" />
       </div>
     </form>
+  ) : (
+    <Redirect to="/signin" />
   );
 };
 

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -26,7 +26,7 @@ const ChangePassword = () => {
     }
 
     try {
-      axios.put("http://localhost:5000/users/password", {
+      await axios.put("http://localhost:5000/users/password", {
         payload: jwt.verify(token, SECRET_KEY),
         currentPassword,
         newPassword,

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -7,6 +7,11 @@ const SECRET_KEY = "abcdefg";
 const ChangePassword = () => {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
+  const token = localStorage.getItem("token");
+
+  if (token) {
+    axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
+  }
 
   const decoded = jwt.verify(localStorage.getItem("token"), SECRET_KEY);
 

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -26,17 +26,11 @@ const ChangePassword = () => {
     }
 
     try {
-      const decoded = jwt.verify(token, SECRET_KEY);
-
-      try {
-        axios.put("http://localhost:5000/users/password", {
-          payload: decoded,
-          currentPassword,
-          newPassword,
-        });
-      } catch (e) {
-        alert(e.message);
-      }
+      axios.put("http://localhost:5000/users/password", {
+        payload: jwt.verify(token, SECRET_KEY),
+        currentPassword,
+        newPassword,
+      });
     } catch (e) {
       alert(e.message);
     }

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -13,7 +13,7 @@ const ChangePassword = () => {
     axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
   }
 
-  const decoded = jwt.verify(localStorage.getItem("token"), SECRET_KEY);
+  const decoded = jwt.verify(token, SECRET_KEY);
 
   const changePassword = async () => {
     if (

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -5,21 +5,25 @@ import jwt from "jsonwebtoken";
 const SECRET_KEY = "abcdefg";
 
 const ChangePassword = () => {
-  const [currentPwd, setCurrentPwd] = useState("");
-  const [newPwd, setNewPwd] = useState("");
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
 
   const decoded = jwt.verify(localStorage.getItem("token"), SECRET_KEY);
 
   const changePassword = async () => {
-    if (!currentPwd.trim() || !newPwd.trim() || newPwd === currentPwd) {
+    if (
+      !currentPassword.trim() ||
+      !newPassword.trim() ||
+      newPassword === currentPassword
+    ) {
       alert("Please enter the correct password");
     }
 
     try {
       axios.put("http://localhost:5000/change/password", {
         id: decoded.id,
-        crntPassword: currentPwd,
-        newPassword: newPwd,
+        currentPassword,
+        newPassword,
       });
     } catch (e) {
       alert(e.message);
@@ -32,16 +36,16 @@ const ChangePassword = () => {
         <p>Current Password</p>
         <input
           type="password"
-          value={currentPwd}
-          onChange={(e) => setCurrentPwd(e.target.value)}
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
         />
       </div>
       <div>
         <p>New Password</p>
         <input
           type="password"
-          value={newPwd}
-          onChange={(e) => setNewPwd(e.target.value)}
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
         />
         <input className="btn" type="submit" value="Enter" />
       </div>

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import axios from "axios";
+import jwt from "jsonwebtoken";
+
+const SECRET_KEY = "abcdefg";
+
+const ChangePassword = () => {
+  const [currentPwd, setCurrentPwd] = useState("");
+  const [newPwd, setNewPwd] = useState("");
+
+  const decoded = jwt.verify(localStorage.getItem("token"), SECRET_KEY);
+
+  const changePassword = async () => {
+    if (!currentPwd.trim() || !newPwd.trim() || newPwd === currentPwd) {
+      alert("Please enter the correct password");
+    }
+
+    try {
+      axios.put("http://localhost:5000/change/password", {
+        id: decoded.id,
+        crntPassword: currentPwd,
+        newPassword: newPwd,
+      });
+    } catch (e) {
+      alert(e.message);
+    }
+  };
+
+  return (
+    <form onSubmit={changePassword}>
+      <div>
+        <p>Current Password</p>
+        <input
+          type="password"
+          value={currentPwd}
+          onChange={(e) => setCurrentPwd(e.target.value)}
+        />
+      </div>
+      <div>
+        <p>New Password</p>
+        <input
+          type="password"
+          value={newPwd}
+          onChange={(e) => setNewPwd(e.target.value)}
+        />
+        <input className="btn" type="submit" value="Enter" />
+      </div>
+    </form>
+  );
+};
+
+export default ChangePassword;

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import axios from "axios";
 import jwt from "jsonwebtoken";
-import { useAuth } from "./ProvideAuth";
-import { Redirect } from "react-router-dom";
 
 const SECRET_KEY = "abcdefg";
 
@@ -10,7 +8,6 @@ const ChangePassword = () => {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const token = localStorage.getItem("token");
-  const { isSignIn } = useAuth();
 
   if (token) {
     axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
@@ -36,7 +33,7 @@ const ChangePassword = () => {
     }
   };
 
-  return isSignIn ? (
+  return (
     <form onSubmit={changePassword}>
       <div>
         <p>Current Password</p>
@@ -56,8 +53,6 @@ const ChangePassword = () => {
         <input className="btn" type="submit" value="Enter" />
       </div>
     </form>
-  ) : (
-    <Redirect to="/signin" />
   );
 };
 

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -13,8 +13,6 @@ const ChangePassword = () => {
     axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
   }
 
-  const decoded = jwt.verify(token, SECRET_KEY);
-
   const changePassword = async () => {
     if (
       !currentPassword.trim() ||
@@ -25,11 +23,17 @@ const ChangePassword = () => {
     }
 
     try {
-      axios.put("http://localhost:5000/users/password", {
-        payload: decoded,
-        currentPassword,
-        newPassword,
-      });
+      const decoded = jwt.verify(token, SECRET_KEY);
+
+      try {
+        axios.put("http://localhost:5000/users/password", {
+          payload: decoded,
+          currentPassword,
+          newPassword,
+        });
+      } catch (e) {
+        alert(e.message);
+      }
     } catch (e) {
       alert(e.message);
     }

--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -1,10 +1,12 @@
 import { useState } from "react";
 import axios from "axios";
+import { useAuth } from "./ProvideAuth";
 
 const ChangePassword = () => {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const token = localStorage.getItem("token");
+  const { payload } = useAuth();
 
   if (token) {
     axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
@@ -21,7 +23,7 @@ const ChangePassword = () => {
 
     try {
       await axios.put("http://localhost:5000/users/password", {
-        payload: JSON.parse(localStorage.getItem("payload")),
+        user: { id: payload.id, email: payload.email },
         currentPassword,
         newPassword,
       });

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,9 +1,11 @@
 import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
 
 const Header = ({ title }) => {
   return (
     <header>
       <h1>{title}</h1>
+      <Link to="/change/password">パスワードの変更</Link>
     </header>
   );
 };

--- a/src/components/ProvideAuth.js
+++ b/src/components/ProvideAuth.js
@@ -11,7 +11,8 @@ export const useAuth = () => {
 
 function useProvideAuth() {
   try {
-    jwt.verify(localStorage.getItem("token") ?? "", SECRET_KEY);
+    const payload = jwt.verify(localStorage.getItem("token") ?? "", SECRET_KEY);
+    localStorage.setItem("payload", JSON.stringify(payload));
   } catch (e) {
     localStorage.clear();
   }

--- a/src/components/ProvideAuth.js
+++ b/src/components/ProvideAuth.js
@@ -1,4 +1,4 @@
-import { useState, useContext, createContext } from "react";
+import { useState, useContext, createContext, useEffect } from "react";
 import jwt from "jsonwebtoken";
 
 const SECRET_KEY = "abcdefg";
@@ -10,17 +10,21 @@ export const useAuth = () => {
 };
 
 function useProvideAuth() {
-  try {
-    const payload = jwt.verify(localStorage.getItem("token") ?? "", SECRET_KEY);
-    localStorage.setItem("payload", JSON.stringify(payload));
-  } catch (e) {
-    localStorage.clear();
-  }
-
   const token = localStorage.getItem("token");
   const [isSignIn, setIsSignIn] = useState(token ? true : false);
+  const [payload, setPayload] = useState(null);
+
+  useEffect(() => {
+    try {
+      setPayload(jwt.verify(localStorage.getItem("token") ?? "", SECRET_KEY));
+    } catch (e) {
+      localStorage.clear();
+      setIsSignIn(false);
+    }
+  }, [isSignIn]);
 
   const UseProvideAuth = {
+    payload,
     isSignIn,
     signIn() {
       setIsSignIn(true);


### PR DESCRIPTION
## 追加内容　2021/07/21 更新

1. `server.put("/users/password")`内で、`req.body`から読み取る変数を`payload`から`user`へ変更、`req.headers`からの読み込みを削除、サーバー側で`verify`された`payload`（後述`2.`）を`req`から読み込み、`verify`していた個所を削除、`user`変数を`foundUser`へ変更
2. `middleware`内で`verify`した値を`req.payload`へ保存するように変更

3. `jwt.verify`を囲っていた`try-catch`を`useEffect`フック内へ移動、ローカルストレージに保存していた`payload`を`state`フックに保存し、`catch`内で`setIsSignIn`フックを使用するために定義を`useProvideAuth`内上部へ移動
4. `axios.put`へ渡すオブジェクトのプロパティ名を`payload`から`user`へ変更、内容に`2.`で保存した`payload`から`id`と`email`を代入

## 追加内容　2021/07/19 更新

1. `ProvideAuth`コンポーネント内でトークンを`verify`した後、ローカルストレージに保存するように変更
2. `axios.put`の`payload`の値をローカルストレージから読み込むように変更
3. ヘッダに付与されたトークンの`verify`された値と、リクエスト内の`payload`の値が同じか検証する機能を追加

## 追加内容　2021/07/16 更新

1. `try-catch`ブロックが入れ子の状態を解消し、`jwt.verify`の返り値を`axios.put`へ直接渡すように変更
2. `changePassword`関数内の`axios`に`await`を追加
3. `PrivateRoute`コンポーネントでラップすることで`ChangePassword`コンポーネント内の`isSignIn`判定によるアクセスコントロールの無駄を削除

## 追加内容　2021/07/15 更新

1. PUT`/users/password`をミドルウェアの下へ移動し冗長なコードを削除
2. `server.js`において、`req.body`から`id`の代わりに`payload`を受け取り、その中から`id`を取り出すように変更
3. `jwt.verify`の第1引数がそれ以前で変数に保存されていたため、その変数を使用するように変更
4. `axios.put`の第2引数の、キー名`id`を`payload`へ、値を`jwt.verify`の返り値へ変更
5. `jwt.verify`のエラーをキャッチするように`try-catch`で囲み、返り値を保存する変数のスコープが、使用箇所(`axios.put`第2引数)とずれないように調整
6. ローカルストレージが空（未サインイン）の状態で`/change/password`へアクセスできないように変更

## 追加内容　2021/07/14 更新
1. 変数名のばらつきを調整
2. アクセスポイントを`/change/password`から`/users/password`へ変更
3. ローカルストレージに有効なトークンがある場合に設定してリクエストを送るように変更
4. `3.`に対応するため設定されたトークンが有効かを識別する機能の追加

## 追加内容

1. `Header.js`コンポーネントに`/change/password`へのリンクを追加
2. `App.js`コンポーネントに`/change/password`へのパスを追加
3. `current password`と`new password`をフォームから、`id`をローカルストレージから`axios.put`へ入力しリクエストを送る機能を追加
4. `server.js`に`id`と`current password`でデータベースからユーザーを照会し、存在すれば`new password`で更新する機能を追加