### PR TITLE
ユーザーへの TODO リストの紐づけ

### DIFF
--- a/db.json
+++ b/db.json
@@ -3,16 +3,19 @@
     {
       "task": "Sleep",
       "completed": false,
+      "userId":1,
       "id": 1
     },
     {
       "task": "Eat",
       "completed": false,
+      "userId":1,
       "id": 2
     },
     {
       "task": "Repeat",
       "completed": false,
+      "userId":1,
       "id": 3
     }
   ],

--- a/server.js
+++ b/server.js
@@ -93,6 +93,15 @@ server.put("/users/password", (req, res) => {
   res.status(200).json("Password Changed");
 });
 
+server.use((req, res, next) => {
+  const { payload } = req;
+  if (req.method === "GET" && req.path === "/todos") {
+    console.log(payload.id);
+    req.query.userId = payload.id.toString();
+  }
+  next();
+});
+
 server.use(router);
 server.listen(5000, () => {
   console.log("JSON Server is running PORT 5000");

--- a/server.js
+++ b/server.js
@@ -32,8 +32,6 @@ server.post("/auth/signup", (req, res) => {
   db.get("users").push(postUser).value();
   db.write();
 
-  db.set(`todos${id}`, []).write();
-
   const token = jwt.sign({ id, email }, SECRET_KEY, OPTION);
   res.status(200).json({ token });
 });

--- a/server.js
+++ b/server.js
@@ -96,7 +96,6 @@ server.put("/users/password", (req, res) => {
 server.use((req, res, next) => {
   const { payload } = req;
   if (req.method === "GET" && req.path === "/todos") {
-    console.log(payload.id);
     req.query.userId = payload.id.toString();
   }
   next();

--- a/server.js
+++ b/server.js
@@ -32,6 +32,8 @@ server.post("/auth/signup", (req, res) => {
   db.get("users").push(postUser).value();
   db.write();
 
+  db.set(`todos${id}`, []).write();
+
   const token = jwt.sign({ id, email }, SECRET_KEY, OPTION);
   res.status(200).json({ token });
 });

--- a/src/components/TodoApp.js
+++ b/src/components/TodoApp.js
@@ -5,6 +5,7 @@ import AddTodo from "./AddTodo";
 import Button from "./Button";
 import FilterButton from "./FilterButton";
 import axios from "axios";
+import { useAuth } from "./ProvideAuth";
 
 const FILTER_LIST = {
   All: () => true,
@@ -30,6 +31,7 @@ const App = () => {
   const filteredTodo =
     filter === "All" ? todos : todos.filter(FILTER_LIST[filter]);
   const token = localStorage.getItem("token");
+  const { payload } = useAuth();
 
   if (token) {
     axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
@@ -38,7 +40,9 @@ const App = () => {
   useEffect(() => {
     const didGetTodo = async () => {
       try {
-        const { data } = await axios.get("http://localhost:5000/todos");
+        const { data } = await axios.get(
+          `http://localhost:5000/todos${payload.id}`
+        );
         await new Promise((r) => setTimeout(r, 500));
 
         setIsLoaded(true);
@@ -50,11 +54,11 @@ const App = () => {
     };
 
     didGetTodo();
-  }, []);
+  }, [payload]);
 
   async function deleteTodo(id) {
     try {
-      await axios.delete(`http://localhost:5000/todos/${id}`);
+      await axios.delete(`http://localhost:5000/todos${payload.id}/${id}`);
 
       setTodos(todos.filter((todo) => todo.id !== id));
     } catch (e) {
@@ -74,10 +78,13 @@ const App = () => {
 
   async function addTodo(todo) {
     try {
-      const { data } = await axios.post("http://localhost:5000/todos", {
-        task: todo,
-        completed: false,
-      });
+      const { data } = await axios.post(
+        `http://localhost:5000/todos${payload.id}`,
+        {
+          task: todo,
+          completed: false,
+        }
+      );
 
       setTodos([...todos, data]);
     } catch (e) {
@@ -88,10 +95,13 @@ const App = () => {
   async function toggleCompleted(todo) {
     try {
       const { id } = todo;
-      const { data } = await axios.put(`http://localhost:5000/todos/${id}`, {
-        ...todo,
-        completed: !todo.completed,
-      });
+      const { data } = await axios.put(
+        `http://localhost:5000/todos${payload.id}/${id}`,
+        {
+          ...todo,
+          completed: !todo.completed,
+        }
+      );
 
       setTodos(todos.map((todo) => (todo.id === id ? data : todo)));
     } catch (e) {

--- a/src/components/TodoApp.js
+++ b/src/components/TodoApp.js
@@ -79,6 +79,7 @@ const App = () => {
       const { data } = await axios.post(`http://localhost:5000/todos`, {
         task: todo,
         completed: false,
+        userId: payload.id,
       });
 
       setTodos([...todos, data]);

--- a/src/components/TodoApp.js
+++ b/src/components/TodoApp.js
@@ -40,9 +40,7 @@ const App = () => {
   useEffect(() => {
     const didGetTodo = async () => {
       try {
-        const { data } = await axios.get(
-          `http://localhost:5000/todos${payload.id}`
-        );
+        const { data } = await axios.get(`http://localhost:5000/todos`);
         await new Promise((r) => setTimeout(r, 500));
 
         setIsLoaded(true);
@@ -58,7 +56,7 @@ const App = () => {
 
   async function deleteTodo(id) {
     try {
-      await axios.delete(`http://localhost:5000/todos${payload.id}/${id}`);
+      await axios.delete(`http://localhost:5000/todos/${id}`);
 
       setTodos(todos.filter((todo) => todo.id !== id));
     } catch (e) {
@@ -78,13 +76,10 @@ const App = () => {
 
   async function addTodo(todo) {
     try {
-      const { data } = await axios.post(
-        `http://localhost:5000/todos${payload.id}`,
-        {
-          task: todo,
-          completed: false,
-        }
-      );
+      const { data } = await axios.post(`http://localhost:5000/todos`, {
+        task: todo,
+        completed: false,
+      });
 
       setTodos([...todos, data]);
     } catch (e) {
@@ -95,13 +90,10 @@ const App = () => {
   async function toggleCompleted(todo) {
     try {
       const { id } = todo;
-      const { data } = await axios.put(
-        `http://localhost:5000/todos${payload.id}/${id}`,
-        {
-          ...todo,
-          completed: !todo.completed,
-        }
-      );
+      const { data } = await axios.put(`http://localhost:5000/todos/${id}`, {
+        ...todo,
+        completed: !todo.completed,
+      });
 
       setTodos(todos.map((todo) => (todo.id === id ? data : todo)));
     } catch (e) {


### PR DESCRIPTION
## 追加内容　21/07/28 更新

1. `server.js`のミドルウェア内の`console.log`を削除

## 追加内容　21/07/27 更新
- 前回の仕様を変更しました
1. `server.js`内の`server.post("/auth/signup")`内の`db.set()`を削除
2. `todos`内のオブジェクトを`userId`プロパティを用いてユーザーと紐づけるミドルウェアを追加
3. URL の`todos`に追加していた`${payload.id}`を削除
4. `addTodo`関数内の`axios.put`内のリクエストオブジェクトに`userId:payload.id`を追加
5. `db.json`内の`todos`内のオブジェクトに、上記変更に伴い`userId`を追加

## 追加内容

1. `server.js`に、`signup`時に`todos+id`(e.g. todos1)のエンドポイントを作成する機能の追加
2. アクセス URL の `todos`を`todos+payload.id`へ変更